### PR TITLE
Add an init system for signal handling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 x-service-options: &service-options
   build: .
+  init: true
   develop:
     # Sync the working directory with the `/app` directory in the container
     watch:


### PR DESCRIPTION
Previously, our camera would hang until killed by docker-compose after
10 seconds. Now it exits immediately.